### PR TITLE
Rsync changes

### DIFF
--- a/rsync-data-sitemap.sh
+++ b/rsync-data-sitemap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+become uni_adm
+rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ noah-login:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build
+rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build

--- a/rsync-data-sitemap.sh
+++ b/rsync-data-sitemap.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
 # Run from codon as uni_adm
 
-rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ noah-login:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build
-rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build
+rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/XXXX_XX/data/ noah-login:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build
+rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/XXXX_XX/data/ pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build

--- a/rsync-data-sitemap.sh
+++ b/rsync-data-sitemap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-become uni_adm
+# Run from codon as uni_adm
+
 rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ noah-login:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build
 rsync -av --delete --include='data-*' --exclude='*' /nfs/production/martin/uniprot/production/sitemap/prod/2023_02/data/ pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap/build

--- a/run.sh
+++ b/run.sh
@@ -32,4 +32,4 @@ wait
 node src/index.js index
 
 # Sync across to production machine
-rsync -avz --delete build pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap
+rsync -av --delete --exclude='data-*' build pg-001:/net/isilonP/public/rw/uniprot/uniprot-sitemap


### PR DESCRIPTION
I haven't tested these scripts but I believe they will work. Some visual inspection at the end of the rsync would be needed to be sure.

The general idea is for sitemaps generated by node to only be copied across and to not delete any files with a `data-` prefix. For sitemaps generated by backend only consider files with a `data-` prefix so as to not interfere with node files.